### PR TITLE
[Feat] - 누적 스탬프로 단골 순위 생성, 조회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.0-SNAPSHOT'
+	id 'org.springframework.boot' version '3.4.1'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.diffplug.spotless' version '7.0.2'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.4.1'
+	id 'org.springframework.boot' version '3.4.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'com.diffplug.spotless' version '7.0.2'
 }

--- a/src/main/java/kr/kro/deom/common/config/RedisConfig.java
+++ b/src/main/java/kr/kro/deom/common/config/RedisConfig.java
@@ -29,7 +29,8 @@ public class RedisConfig {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(redisHost, redisPort);
+        RedisStandaloneConfiguration configuration =
+                new RedisStandaloneConfiguration(redisHost, redisPort);
 
         if (redisUsername != null && !redisUsername.isEmpty()) {
             configuration.setUsername(redisUsername);

--- a/src/main/java/kr/kro/deom/domain/analysis/controller/CustomerAnalysisController.java
+++ b/src/main/java/kr/kro/deom/domain/analysis/controller/CustomerAnalysisController.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import kr.kro.deom.common.response.ApiResponse;
 import kr.kro.deom.common.response.CommonSuccessCode;
+import kr.kro.deom.domain.analysis.dto.UserStampRankDto;
 import kr.kro.deom.domain.analysis.service.CustomerAnalysisService;
-import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -24,9 +24,9 @@ public class CustomerAnalysisController {
 
     @Operation(summary = "누적 스탬프 고객 순위 조회", description = "누적 적립 스탬프가 많은 순서로 고객을 조회합니다.")
     @GetMapping("/customer")
-    public ResponseEntity<ApiResponse<List<UserAccumulatedStampsDto>>> getCustomerRanking(
+    public ResponseEntity<ApiResponse<List<UserStampRankDto>>> getCustomerRanking(
             @RequestParam Long storeId) {
-        List<UserAccumulatedStampsDto> response =
+        List<UserStampRankDto> response =
                 customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
 
         return ResponseEntity.ok(ApiResponse.success(CommonSuccessCode.OK, response));

--- a/src/main/java/kr/kro/deom/domain/analysis/controller/CustomerAnalysisController.java
+++ b/src/main/java/kr/kro/deom/domain/analysis/controller/CustomerAnalysisController.java
@@ -1,0 +1,34 @@
+package kr.kro.deom.domain.analysis.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import kr.kro.deom.common.response.ApiResponse;
+import kr.kro.deom.common.response.CommonSuccessCode;
+import kr.kro.deom.domain.analysis.service.CustomerAnalysisService;
+import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/analysis")
+@RequiredArgsConstructor
+@Tag(name = "analysis", description = "단골 고객 분석 API")
+public class CustomerAnalysisController {
+
+    private final CustomerAnalysisService customerAnalysisService;
+
+    @Operation(summary = "누적 스탬프 고객 순위 조회", description = "누적 적립 스탬프가 많은 순서로 고객을 조회합니다.")
+    @GetMapping("/customer")
+    public ResponseEntity<ApiResponse<List<UserAccumulatedStampsDto>>> getCustomerRanking(
+            @RequestParam Long storeId) {
+        List<UserAccumulatedStampsDto> response =
+                customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
+
+        return ResponseEntity.ok(ApiResponse.success(CommonSuccessCode.OK, response));
+    }
+}

--- a/src/main/java/kr/kro/deom/domain/analysis/dto/UserStampRankDto.java
+++ b/src/main/java/kr/kro/deom/domain/analysis/dto/UserStampRankDto.java
@@ -1,0 +1,16 @@
+package kr.kro.deom.domain.analysis.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserStampRankDto {
+    private Long userId;
+    private Integer accumulatedStampAmount;
+    private Integer rank;
+}

--- a/src/main/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisService.java
+++ b/src/main/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisService.java
@@ -1,6 +1,8 @@
 package kr.kro.deom.domain.analysis.service;
 
+import java.util.ArrayList;
 import java.util.List;
+import kr.kro.deom.domain.analysis.dto.UserStampRankDto;
 import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
 import kr.kro.deom.domain.myStamp.service.MyStampService;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +11,49 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class CustomerAnalysisService {
-    private MyStampService myStampService;
+    private final MyStampService myStampService;
 
-    public List<UserAccumulatedStampsDto> getCustomerRankingByAccumulatedStamp(Long storeId) {
-        return myStampService.getUserAccumulatedStamps(storeId);
+    public List<UserStampRankDto> getCustomerRankingByAccumulatedStamp(Long storeId) {
+        List<UserAccumulatedStampsDto> userAccumulatedStamps =
+                myStampService.getUserAccumulatedStamps(storeId);
+
+        if (userAccumulatedStamps.isEmpty()) {
+            return List.of();
+        }
+
+        return makeUserStampRankDto(userAccumulatedStamps);
+    }
+
+    private List<UserStampRankDto> makeUserStampRankDto(
+            List<UserAccumulatedStampsDto> userAccumulatedStamps) {
+        List<UserStampRankDto> result = new ArrayList<>();
+        int currentRank = 1;
+        int previousAccumulated = -1;
+        int sameRankCount = 1;
+
+        for (UserAccumulatedStampsDto user : userAccumulatedStamps) {
+            int accumulated = user.getAccumulatedStampAmount();
+
+            if (accumulated == previousAccumulated) {
+                sameRankCount++;
+            } else {
+                currentRank += sameRankCount - 1;
+                if (previousAccumulated != -1) {
+                    currentRank += 1;
+                }
+                sameRankCount = 1;
+            }
+
+            result.add(
+                    UserStampRankDto.builder()
+                            .userId(user.getUserId())
+                            .accumulatedStampAmount(accumulated)
+                            .rank(currentRank)
+                            .build());
+
+            previousAccumulated = accumulated;
+        }
+
+        return result;
     }
 }

--- a/src/main/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisService.java
+++ b/src/main/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisService.java
@@ -1,0 +1,17 @@
+package kr.kro.deom.domain.analysis.service;
+
+import java.util.List;
+import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
+import kr.kro.deom.domain.myStamp.service.MyStampService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerAnalysisService {
+    private MyStampService myStampService;
+
+    public List<UserAccumulatedStampsDto> getCustomerRankingByAccumulatedStamp(Long storeId) {
+        return myStampService.getUserAccumulatedStamps(storeId);
+    }
+}

--- a/src/main/java/kr/kro/deom/domain/myStamp/dto/UserAccumulatedStampsDto.java
+++ b/src/main/java/kr/kro/deom/domain/myStamp/dto/UserAccumulatedStampsDto.java
@@ -1,0 +1,11 @@
+package kr.kro.deom.domain.myStamp.dto;
+
+public class UserAccumulatedStampsDto {
+    private Long userId;
+    private Integer accumulatedStampAmount;
+
+    public UserAccumulatedStampsDto(Long userId, Integer accumulatedStampAmount) {
+        this.userId = userId;
+        this.accumulatedStampAmount = accumulatedStampAmount;
+    }
+}

--- a/src/main/java/kr/kro/deom/domain/myStamp/dto/UserAccumulatedStampsDto.java
+++ b/src/main/java/kr/kro/deom/domain/myStamp/dto/UserAccumulatedStampsDto.java
@@ -1,11 +1,15 @@
 package kr.kro.deom.domain.myStamp.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserAccumulatedStampsDto {
     private Long userId;
     private Integer accumulatedStampAmount;
-
-    public UserAccumulatedStampsDto(Long userId, Integer accumulatedStampAmount) {
-        this.userId = userId;
-        this.accumulatedStampAmount = accumulatedStampAmount;
-    }
 }

--- a/src/main/java/kr/kro/deom/domain/myStamp/entity/MyStamp.java
+++ b/src/main/java/kr/kro/deom/domain/myStamp/entity/MyStamp.java
@@ -25,9 +25,13 @@ public class MyStamp extends BaseTimeEntity {
     @Column(name = "stamp_amount", nullable = false)
     private Integer stampAmount;
 
+    @Column(name = "accumulated_stamp_amount", nullable = false)
+    private Integer accumulatedStampAmount;
+
     public MyStamp(Long userId, Long storeId, Integer stampAmount) {
         this.userId = userId;
         this.storeId = storeId;
         this.stampAmount = stampAmount;
+        this.accumulatedStampAmount = stampAmount;
     }
 }

--- a/src/main/java/kr/kro/deom/domain/myStamp/repository/MyStampRepository.java
+++ b/src/main/java/kr/kro/deom/domain/myStamp/repository/MyStampRepository.java
@@ -2,6 +2,7 @@ package kr.kro.deom.domain.myStamp.repository;
 
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.List;
+import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
 import kr.kro.deom.domain.myStamp.entity.MyStamp;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -25,7 +26,7 @@ public interface MyStampRepository extends JpaRepository<MyStamp, Long> {
 
     @Modifying
     @Query(
-            "UPDATE MyStamp ms SET ms.stampAmount = ms.stampAmount + :amount WHERE ms.userId = :userId AND ms.storeId = :storeId")
+            "UPDATE MyStamp ms SET ms.stampAmount = ms.stampAmount + :amount, ms.accumulatedStampAmount = ms.accumulatedStampAmount + :amount WHERE ms.userId = :userId AND ms.storeId = :storeId")
     Integer incrementStamp(
             @Param("userId") Long userId,
             @Param("storeId") Long storeId,
@@ -37,4 +38,12 @@ public interface MyStampRepository extends JpaRepository<MyStamp, Long> {
     // 가게별 스탬프 수량 확인용
     @Query("SELECT ms FROM MyStamp ms WHERE ms.userId = :userId AND ms.stampAmount > 0")
     List<MyStamp> findAllByUserIdWithStamps(@Param("userId") Long userId);
+
+    @Query(
+            "SELECT new kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto("
+                    + "ms.userId, ms.accumulatedStampAmount) "
+                    + "FROM MyStamp ms "
+                    + "WHERE ms.storeId = :storeId "
+                    + "ORDER BY ms.accumulatedStampAmount DESC")
+    List<UserAccumulatedStampsDto> findUserAccumulatedByStoreId(@Param("storeId") Long storeId);
 }

--- a/src/main/java/kr/kro/deom/domain/myStamp/service/MyStampService.java
+++ b/src/main/java/kr/kro/deom/domain/myStamp/service/MyStampService.java
@@ -1,6 +1,7 @@
 package kr.kro.deom.domain.myStamp.service;
 
 import java.util.List;
+import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
 import kr.kro.deom.domain.myStamp.repository.MyStampRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,10 @@ public class MyStampService {
 
     public Integer getMyStampAmount(Long userId, Long storeId) {
         return myStampRepository.findStampAmountByUserIdAndStoreId(userId, storeId);
+    }
+
+    public List<UserAccumulatedStampsDto> getUserAccumulatedStamps(Long storeId) {
+        return myStampRepository.findUserAccumulatedByStoreId(storeId);
     }
 
     public List<Long> getMyStoreIds(Long userId) {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -35,6 +35,7 @@ spring:
           google:
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_CLIENT_SECRET}
+            redirect-uri: "http://localhost:8080/login/oauth2/code/google"
             scope:
               - email
               - profile
@@ -42,7 +43,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
             client-name: Kakao
             authorization-grant-type: authorization_code
             client-authentication-method: client_secret_post
@@ -53,7 +54,7 @@ spring:
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            redirect-uri: "http://localhost:8080/login/oauth2/code/naver"
             client-name: Naver
             authorization-grant-type: authorization_code
             scope:
@@ -86,6 +87,9 @@ logging:
 # 개발 환경 서버 설정
 server:
   port: ${SERVER_PORT}
+  servlet:
+    context-path: /
+  forward-headers-strategy: native
   error:
     include-stacktrace: always
     include-message: always

--- a/src/test/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisServiceTest.java
+++ b/src/test/java/kr/kro/deom/domain/analysis/service/CustomerAnalysisServiceTest.java
@@ -1,0 +1,147 @@
+package kr.kro.deom.domain.analysis.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import kr.kro.deom.domain.analysis.dto.UserStampRankDto;
+import kr.kro.deom.domain.myStamp.dto.UserAccumulatedStampsDto;
+import kr.kro.deom.domain.myStamp.service.MyStampService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerAnalysisServiceTest {
+
+    @Mock private MyStampService myStampService;
+
+    @InjectMocks private CustomerAnalysisService customerAnalysisService;
+
+    @Test
+    @DisplayName("고객 누적 스탬프 순위 조회")
+    void getCustomerRankingByAccumulatedStamp() {
+        // given
+        Long storeId = 1L;
+        List<UserAccumulatedStampsDto> userAccumulatedStamps =
+                Arrays.asList(
+                        new UserAccumulatedStampsDto(1L, 100), // 1등
+                        new UserAccumulatedStampsDto(2L, 80), // 2등
+                        new UserAccumulatedStampsDto(3L, 50) // 3등
+                        );
+
+        when(myStampService.getUserAccumulatedStamps(storeId)).thenReturn(userAccumulatedStamps);
+
+        // when
+        List<UserStampRankDto> result =
+                customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
+
+        // then
+        assertEquals(3, result.size());
+
+        // 1등 검증
+        assertEquals(1L, result.get(0).getUserId());
+        assertEquals(100, result.get(0).getAccumulatedStampAmount());
+        assertEquals(1, result.get(0).getRank());
+
+        // 2등 검증
+        assertEquals(2L, result.get(1).getUserId());
+        assertEquals(80, result.get(1).getAccumulatedStampAmount());
+        assertEquals(2, result.get(1).getRank());
+
+        // 3등 검증
+        assertEquals(3L, result.get(2).getUserId());
+        assertEquals(50, result.get(2).getAccumulatedStampAmount());
+        assertEquals(3, result.get(2).getRank());
+
+        verify(myStampService, times(1)).getUserAccumulatedStamps(storeId);
+    }
+
+    @Test
+    @DisplayName("고객 누적 스탬프 순위 조회 - 동점 처리")
+    void getCustomerRankingByAccumulatedStamp_withTiedRanks() {
+        // given
+        Long storeId = 1L;
+        List<UserAccumulatedStampsDto> userAccumulatedStamps =
+                Arrays.asList(
+                        new UserAccumulatedStampsDto(1L, 100), // 1등
+                        new UserAccumulatedStampsDto(2L, 80), // 2등
+                        new UserAccumulatedStampsDto(3L, 80), // 2등 (동점)
+                        new UserAccumulatedStampsDto(4L, 50), // 4등
+                        new UserAccumulatedStampsDto(5L, 30), // 5등
+                        new UserAccumulatedStampsDto(6L, 20), // 6등
+                        new UserAccumulatedStampsDto(7L, 20), // 6등 (동점)
+                        new UserAccumulatedStampsDto(8L, 20), // 6등 (동점)
+                        new UserAccumulatedStampsDto(9L, 10) // 9등
+                        );
+
+        when(myStampService.getUserAccumulatedStamps(storeId)).thenReturn(userAccumulatedStamps);
+
+        // when
+        List<UserStampRankDto> result =
+                customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
+
+        // then
+        assertEquals(9, result.size());
+
+        assertAll(
+                () -> assertEquals(1, result.get(0).getRank()), // 100 pts
+                () -> assertEquals(2, result.get(1).getRank()), // 80 pts
+                () -> assertEquals(2, result.get(2).getRank()), // 80 pts
+                () -> assertEquals(4, result.get(3).getRank()), // 50 pts
+                () -> assertEquals(5, result.get(4).getRank()), // 30 pts
+                () -> assertEquals(6, result.get(5).getRank()), // 20 pts
+                () -> assertEquals(6, result.get(6).getRank()), // 20 pts
+                () -> assertEquals(6, result.get(7).getRank()), // 20 pts
+                () -> assertEquals(9, result.get(8).getRank()) // 10 pts
+                );
+
+        verify(myStampService, times(1)).getUserAccumulatedStamps(storeId);
+    }
+
+    @Test
+    @DisplayName("고객 누적 스탬프 순위 조회 - 빈 리스트")
+    void getCustomerRankingByAccumulatedStamp_emptyList() {
+        // given
+        Long storeId = 1L;
+        List<UserAccumulatedStampsDto> emptyList = Collections.emptyList();
+
+        when(myStampService.getUserAccumulatedStamps(storeId)).thenReturn(emptyList);
+
+        // when
+        List<UserStampRankDto> result =
+                customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
+
+        // then
+        assertTrue(result.isEmpty());
+        verify(myStampService, times(1)).getUserAccumulatedStamps(storeId);
+    }
+
+    @Test
+    @DisplayName("고객 누적 스탬프 순위 조회 - 단일 사용자")
+    void getCustomerRankingByAccumulatedStamp_singleUser() {
+        // given
+        Long storeId = 1L;
+        List<UserAccumulatedStampsDto> singleUser =
+                Arrays.asList(new UserAccumulatedStampsDto(1L, 100));
+
+        when(myStampService.getUserAccumulatedStamps(storeId)).thenReturn(singleUser);
+
+        // when
+        List<UserStampRankDto> result =
+                customerAnalysisService.getCustomerRankingByAccumulatedStamp(storeId);
+
+        // then
+        assertEquals(1, result.size());
+        assertEquals(1L, result.get(0).getUserId());
+        assertEquals(100, result.get(0).getAccumulatedStampAmount());
+        assertEquals(1, result.get(0).getRank());
+
+        verify(myStampService, times(1)).getUserAccumulatedStamps(storeId);
+    }
+}


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
* 누적 스탬프 수를 이용하여 단골 순위를 생성하고 조회한다.
* 자바 버전 이슈로 실행이 안 되어서, 다운그레이드 했습니다.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
* 누적 스탬프 수를 이용해 단골 순위 생성
    * 누적 스탬프 수가 같을 경우(동점) 동점 순위를 부여하고 이후에는 동점자 수만큼 밀린 순위를 부여함.
    * ex) 1등, 1등, 3등...
    


